### PR TITLE
Version change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ SHELL := /bin/bash
 
 GO111MODULE := on
 
-GOPKG += github.com/veraison/evcli/cmd/psa
-GOPKG += github.com/veraison/evcli/cmd/cca
+GOPKG += github.com/veraison/evcli/v2/cmd/psa
+GOPKG += github.com/veraison/evcli/v2/cmd/cca
 
 MOCKGEN := $(shell go env GOPATH)/bin/mockgen
 INTERFACES := common/iveraisonclient.go

--- a/cmd/cca/check.go
+++ b/cmd/cca/check.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/veraison/ccatoken"
-	"github.com/veraison/evcli/common"
+	"github.com/veraison/evcli/v2/common"
 )
 
 var (

--- a/cmd/cca/create.go
+++ b/cmd/cca/create.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"github.com/veraison/evcli/common"
+	"github.com/veraison/evcli/v2/common"
 )
 
 var (

--- a/cmd/cca/test_common.go
+++ b/cmd/cca/test_common.go
@@ -1,6 +1,6 @@
 package cca
 
-import "github.com/veraison/evcli/common"
+import "github.com/veraison/evcli/v2/common"
 
 var (
 	testInvalidKey = []byte(`{}`)

--- a/cmd/cca/verify_as_attester.go
+++ b/cmd/cca/verify_as_attester.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/veraison/apiclient/verification"
 	"github.com/veraison/ccatoken"
-	"github.com/veraison/evcli/common"
+	"github.com/veraison/evcli/v2/common"
 	"github.com/veraison/go-cose"
 	"github.com/veraison/psatoken"
 )

--- a/cmd/cca/verify_as_attester_test.go
+++ b/cmd/cca/verify_as_attester_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	mock_deps "github.com/veraison/evcli/cmd/mocks"
-	"github.com/veraison/evcli/common"
+	mock_deps "github.com/veraison/evcli/v2/cmd/mocks"
+	"github.com/veraison/evcli/v2/common"
 )
 
 func Test_AttesterCmd_claims_not_found(t *testing.T) {

--- a/cmd/cca/verify_as_relyingparty.go
+++ b/cmd/cca/verify_as_relyingparty.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/veraison/apiclient/verification"
 	"github.com/veraison/ccatoken"
-	"github.com/veraison/evcli/common"
+	"github.com/veraison/evcli/v2/common"
 )
 
 var (

--- a/cmd/cca/verify_as_relyingparty_test.go
+++ b/cmd/cca/verify_as_relyingparty_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	mock_deps "github.com/veraison/evcli/cmd/mocks"
+	mock_deps "github.com/veraison/evcli/v2/cmd/mocks"
 )
 
 func Test_RelyingPartyCmd_token_not_found(t *testing.T) {

--- a/cmd/psa/check.go
+++ b/cmd/psa/check.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"github.com/veraison/evcli/common"
+	"github.com/veraison/evcli/v2/common"
 )
 
 var (

--- a/cmd/psa/create.go
+++ b/cmd/psa/create.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"github.com/veraison/evcli/common"
+	"github.com/veraison/evcli/v2/common"
 	"github.com/veraison/psatoken"
 )
 

--- a/cmd/psa/test_common.go
+++ b/cmd/psa/test_common.go
@@ -4,7 +4,7 @@
 package psa
 
 import (
-	"github.com/veraison/evcli/common"
+	"github.com/veraison/evcli/v2/common"
 	"github.com/veraison/psatoken"
 )
 

--- a/cmd/psa/verify_as_attester.go
+++ b/cmd/psa/verify_as_attester.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/veraison/apiclient/verification"
-	"github.com/veraison/evcli/common"
+	"github.com/veraison/evcli/v2/common"
 	"github.com/veraison/go-cose"
 	"github.com/veraison/psatoken"
 )

--- a/cmd/psa/verify_as_attester_test.go
+++ b/cmd/psa/verify_as_attester_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	mock_deps "github.com/veraison/evcli/cmd/mocks"
-	"github.com/veraison/evcli/common"
+	mock_deps "github.com/veraison/evcli/v2/cmd/mocks"
+	"github.com/veraison/evcli/v2/common"
 )
 
 func Test_AttesterCmd_claims_not_found(t *testing.T) {

--- a/cmd/psa/verify_as_relyingparty.go
+++ b/cmd/psa/verify_as_relyingparty.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/veraison/apiclient/verification"
-	"github.com/veraison/evcli/common"
+	"github.com/veraison/evcli/v2/common"
 	"github.com/veraison/psatoken"
 )
 

--- a/cmd/psa/verify_as_relyingparty_test.go
+++ b/cmd/psa/verify_as_relyingparty_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	mock_deps "github.com/veraison/evcli/cmd/mocks"
+	mock_deps "github.com/veraison/evcli/v2/cmd/mocks"
 )
 
 func Test_RelyingPartyCmd_token_not_found(t *testing.T) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,8 +8,8 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/veraison/evcli/cmd/cca"
-	"github.com/veraison/evcli/cmd/psa"
+	"github.com/veraison/evcli/v2/cmd/cca"
+	"github.com/veraison/evcli/v2/cmd/psa"
 
 	"github.com/spf13/viper"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/veraison/evcli
+module github.com/veraison/evcli/v2
 
 go 1.17
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@
 package main
 
 import (
-	"github.com/veraison/evcli/cmd"
+	"github.com/veraison/evcli/v2/cmd"
 )
 
 func main() {


### PR DESCRIPTION
EVCLI CCA token naming is aligned with the specification. This requires evcli version change