### PR TITLE
revert a c&p error introduced in 3457479

### DIFF
--- a/cmd/cca/verify_as.go
+++ b/cmd/cca/verify_as.go
@@ -11,7 +11,7 @@ import (
 
 var verifyValidArgs = []string{"attester", "relying-party"}
 
-const CCATokenMediaType = `application/eat-collection; profile="tag:arm.com,2023:cca_platform#1.0.0"`
+const CCATokenMediaType = `application/eat-collection; profile="http://arm.com/CCA-SSD/1.0.0"`
 
 var verifyAsCmd = &cobra.Command{
 	Use:   "verify-as",


### PR DESCRIPTION
Revert a copy&paste error introduced in 3457479 that broke compatibility with the Veraison services.